### PR TITLE
Removes logging called by vendor Config file

### DIFF
--- a/src/World.php
+++ b/src/World.php
@@ -102,6 +102,5 @@ class World implements \Feature\Contracts\World
      */
     public function log($name, $variant, $selector)
     {
-        Log::info(sprintf("Name %s, Variant %s Selector %s", $name, $variant, $selector));
     }
 }


### PR DESCRIPTION
Removes the log message to cut down on the amount of vendor-controlled log messages in the logs of consuming projects.

The logging is triggered by a [vendor file](https://github.com/praswicaksono/feature/blob/8df90aa05812da9eafc159d5ca16bb730e2d9c7d/src/Feature/Config.php#L238), and is only reporting that a feature flag has been hit. 

Consumers may not want to know every time this happens (e.g. one or more new messages per page load while browsing an app) and can set up their own logging on their app for reporting this information when desired.