### PR TITLE
Load the service provider automatically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
   "extra": {
     "branch-alias": {
       "dev-master": "1.0-dev"
+    },
+    "laravel": {
+            "providers": [
+                "AlfredNutileInc\\LaravelFeatureFlags\\FeatureFlagsProvider"
+            ]
     }
   },
   "autoload-dev": {


### PR DESCRIPTION
This is a new feature in Laravel 5.5 for automatic discovery,  to load the service provider automatically upon installation of the package.