### PR TITLE
Fixes typo in auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "laravel": {
       "providers": [
-        "AlfredNutileInc\\LaravelFeatureFlag\\FeatureFlagsProvider"
+        "AlfredNutileInc\\LaravelFeatureFlags\\FeatureFlagsProvider"
       ]
     }
   },


### PR DESCRIPTION
Hello. 

Getting the following error when requiring this package with composer:

```
In ProviderRepository.php line 208:

  Class 'AlfredNutileInc\LaravelFeatureFlag\FeatureFlagsProvider' not found


Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1

Installation failed, reverting ./composer.json to its original content.
```

Looks like the service provider's namespace is missing an `s`.