### PR TITLE
Sync Flags Command

### DIFF
--- a/config/laravel-feature-flag.php
+++ b/config/laravel-feature-flag.php
@@ -11,14 +11,24 @@ return [
     | by the laravel-feature-flag package. You may pass in a string for a
     | middleware or an array for multiple middleware.
     |
- */
+    */
 
     'route_middleware' => ['web', 'auth'],
     'default_view' => env("LARAVEL_FEATURE_FLAG_VIEW", 'laravel-feature-flag::default_layout'),
     'logging' => env("LARAVEL_FEATURE_FLAG_LOGGING"),
-    'add_link_to_menu' => false
+    'add_link_to_menu' => false,
 
     // Example with multiple middleware:
     // 'route_middleware' => "['auth', 'custom_middleware']",
+
+    'sync_flags' => [
+        // Key is the flag key (machine name like identifier) and value is the default value it should have.
+        // The value will get JSON encoded so structured data can be used too, like `['users' => [/*...*/]]`.
+        // E.g.
+        // 'personal-homepage' => 'off',
+        // 'edit-document' => [
+        //     'users' => [],
+        // ],
+    ],
 
 ];

--- a/src/Console/Command/SyncFlags.php
+++ b/src/Console/Command/SyncFlags.php
@@ -13,7 +13,7 @@ class SyncFlags extends Command {
      *
      * @var string
      */
-    protected $signature = 'feature-flag:sync {--force}';
+    protected $signature = 'feature-flag:sync {--force} {--skip-cleanup}';
 
 
     /**
@@ -40,23 +40,46 @@ class SyncFlags extends Command {
      */
     public function handle()
     {
+        if (!$this->option('force') && !$this->confirm('Are you sure?')) {
+            return;
+        }
+
         $default_flags = (array) $this->getLaravel()
             ->make('config')
             ->get('laravel-feature-flag.sync_flags', []);
 
         foreach ($default_flags as $key => $default_value) {
-            if (FeatureFlag::whereKey($key)->exists()) {
+            if (FeatureFlag::where('key', $key)->exists()) {
                 $this->printAndLogLine(sprintf('Feature flag with key "%s" already exists', $key));
                 continue;
             }
 
             // Otherwise, create the new flag with default value.
-            $feature = new FeatureFlag();
-            $feature->key = $key;
-            $feature->variants = $default_value;
-            $feature->save();
+            $flag = $this->createFeatureFlag($key, $default_value);
 
-            $this->printAndLogInfo(sprintf('Feature flag created with key "%s" with variant "%s"', $key, json_encode($default_value)));
+            $this->printAndLogInfo(sprintf('Feature flag created with key "%s" [%d] with variant "%s"', $key, $flag->id, json_encode($default_value)));
+        }
+
+        if ($this->option('skip-cleanup')) {
+            return;
+        }
+
+        // Tidy up and flags that are not present any more.
+        $existing_keys = array_keys($default_flags);
+
+        $query = FeatureFlag::whereNotIn('key', $existing_keys);
+
+        if ($query->exists()) {
+            $this->printAndLogLine(sprintf('Removing flags not defined in sync_flags'));
+
+            $query->chunk(100, function($chunk) {
+                foreach ($chunk as $flag) {
+                    $flag->delete();
+                    $this->printAndLogLine(sprintf('Feature flag with key "%s" deleted', $flag->key));
+                }
+            });
+        } else {
+            $this->printAndLogLine(sprintf('No flags to remove'));
         }
     }
 
@@ -70,5 +93,15 @@ class SyncFlags extends Command {
     {
         $this->info($line);
         $this->logger->info($line);
+    }
+
+    private function createFeatureFlag($key, $value)
+    {
+        $flag = new FeatureFlag();
+        $flag->key = $key;
+        $flag->variants = $value;
+        $flag->save();
+
+        return $flag;
     }
 }

--- a/src/Console/Command/SyncFlags.php
+++ b/src/Console/Command/SyncFlags.php
@@ -6,7 +6,8 @@ use AlfredNutileInc\LaravelFeatureFlags\FeatureFlag;
 use Illuminate\Console\Command;
 use Illuminate\Log\Writer;
 
-class SyncFlags extends Command {
+class SyncFlags extends Command
+{
 
     /**
      * The name and signature of the console command.
@@ -57,7 +58,14 @@ class SyncFlags extends Command {
             // Otherwise, create the new flag with default value.
             $flag = $this->createFeatureFlag($key, $default_value);
 
-            $this->printAndLogInfo(sprintf('Feature flag created with key "%s" [%d] with variant "%s"', $key, $flag->id, json_encode($default_value)));
+            $this->printAndLogInfo(
+                sprintf(
+                    'Feature flag created with key "%s" [%d] with variant "%s"',
+                    $key,
+                    $flag->id,
+                    json_encode($default_value)
+                )
+            );
         }
 
         if ($this->option('skip-cleanup')) {
@@ -72,7 +80,7 @@ class SyncFlags extends Command {
         if ($query->exists()) {
             $this->printAndLogLine(sprintf('Removing flags not defined in sync_flags'));
 
-            $query->chunk(100, function($chunk) {
+            $query->chunk(100, function ($chunk) {
                 foreach ($chunk as $flag) {
                     $flag->delete();
                     $this->printAndLogLine(sprintf('Feature flag with key "%s" deleted', $flag->key));

--- a/src/FeatureFlagsProvider.php
+++ b/src/FeatureFlagsProvider.php
@@ -2,6 +2,7 @@
 
 namespace AlfredNutileInc\LaravelFeatureFlags;
 
+use AlfredNutileInc\LaravelFeatureFlags\Console\Command\SyncFlags;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Support\Facades\Log;
@@ -43,6 +44,8 @@ class FeatureFlagsProvider extends ServiceProvider
         $this->defineFeatureFlagGate($gate);
 
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
+
+        $this->registerCommands();
     }
 
     /**
@@ -133,5 +136,10 @@ class FeatureFlagsProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../config/laravel-feature-flag.php' => config_path('laravel-feature-flag.php'),
         ], 'config');
+    }
+
+    private function registerCommands()
+    {
+        $this->commands(SyncFlags::class);
     }
 }

--- a/tests/SyncFlagsCommandTest.php
+++ b/tests/SyncFlagsCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use AlfredNutileInc\LaravelFeatureFlags\FeatureFlag;
+use Illuminate\Support\Facades\Artisan;
+
+class SyncFlagsCommandTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    public function testShouldSyncFeatureFlags()
+    {
+
+        factory(FeatureFlag::class, 2)->create(
+            [
+                'variants' => 'on',
+            ]
+        );
+
+        $sync_flags = [
+            'new_flag' => 'off',
+        ];
+
+        $this->app['config']->set('laravel-feature-flag.sync_flags', $sync_flags);
+
+        Artisan::call('feature-flag:sync', ['--force' => true]);
+
+        // Only the new_flag should be left.
+        $this->assertSame(1, FeatureFlag::count());
+
+        $added_flag = FeatureFlag::where('key', 'new_flag')->first();
+
+        $this->assertSame('new_flag', $added_flag->key);
+        $this->assertSame('off', $added_flag->variants);
+    }
+
+    public function testShouldSyncNotOverwriteFeatureFlags()
+    {
+
+        factory(FeatureFlag::class)->create(
+            [
+                'key' => 'existing_flag',
+                'variants' => 'on',
+            ]
+        );
+
+        $sync_flags = [
+            'existing_flag' => 'off',
+        ];
+
+        $this->app['config']->set('laravel-feature-flag.sync_flags', $sync_flags);
+
+        Artisan::call('feature-flag:sync', ['--force' => true]);
+
+        // Only the new_flag should be left.
+        $this->assertSame(1, FeatureFlag::count());
+
+        $existing_flag = FeatureFlag::where('key', 'existing_flag')->first();
+
+        // Should still be 'on', not overwritten to 'off'.
+        $this->assertSame('on', $existing_flag->variants);
+    }
+
+    public function testShouldSyncFeatureFlagsSkippingCleanup()
+    {
+
+        factory(FeatureFlag::class, 2)->create(
+            [
+                'variants' => 'on',
+            ]
+        );
+
+        $sync_flags = [
+            'new_flag' => 'off',
+        ];
+
+        $this->app['config']->set('laravel-feature-flag.sync_flags', $sync_flags);
+
+        Artisan::call('feature-flag:sync', ['--force' => true, '--skip-cleanup' => true]);
+
+        // Only the new_flag should be left.
+        $this->assertSame(3, FeatureFlag::count());
+    }
+}


### PR DESCRIPTION
This adds:

- A new command to sync flags from a new `sync_flags` config variable.  The command will add new flags, and remove ones that aren't defined anymore (This can be worked around by using the `--skip-cleanup` option on the command). It will **not** overwrite values for flags that already exist in the database.
- Tests

I went with a command instead of flat out defining them in code, as we ideal need to keep any data that has been overridden in the database. So if a flag starts as on, but was turned off in the DB, we should keep that.